### PR TITLE
Breaking: bump Node.js from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Additional Tags
 description: Create major and minor git tags from the last tag
 runs:
-  using: node12
+  using: node16
   main: index.js


### PR DESCRIPTION
Running with Node 12 is deprecated as of 2022-09-27 and log a warning message.

Here is the warning message that is logged when using the latest release of the `surge-preview` action.
_Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: afc163/surge-preview_